### PR TITLE
support single tx for multiple markets + bump specific markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,16 @@ ENDPOINT_URL=... KEYPAIR=[1,3,4...] ./start-cranker.sh
 
 to run in the background, pass "-d" or "--daemon"
 
-env args to pay attention to:
+optional env args:
 
 ```
-  HIGH_FEE_MARKETS,      // markets to apply a priority fee for e.g. [0,1] to apply on the first two markets in markets.json
-  DEFAULT_CU_PRICE,     // extra microlamports per cu for any market
-  PRIORITY_CU_PRICE,     // extra microlamports per cu for high fee markets
+  BUMP_MARKETS          // comma seperated list to force PRIORITY_CU_PRICE for market addresses
+  CU_PRICE          // minimum additional micro lamports for all transactions
+  PRIORITY_QUEUE_LIMIT  // force PRIORITY_CU_PRICE for transactions when events exceed this value
+  PRIORITY_CU_PRICE     // additional micro lamports for BUMP_MARKETS & PRIORITY_QUEUE_LIMIT
 ```
 
 #### TODO:
 
-- Crank multiple markets in the same TX
-- Poll the list of top markets using https://openserum.io/api/serum/markets.json?min24hVolume=100000
 - Dynamic priority fee using getRecentPrioritizationFees
 - Dynamic frequency based on queue length

--- a/src/scripts/crank.ts
+++ b/src/scripts/crank.ts
@@ -245,7 +245,6 @@ async function run() {
           transactionInstructions.forEach(function (crankInstruction) {
             //check the instruction for flag to bump fee
             instructionBumpMap.get(crankInstruction) ? shouldBumpFee = true : null;
-            crankTransaction.add(crankInstruction);
           });
 
           if(shouldBumpFee || cuPrice){
@@ -255,6 +254,8 @@ async function run() {
                 })
             );
           }
+
+          crankTransaction.add(...transactionInstructions);
 
           crankTransaction.sign(payer);
 


### PR DESCRIPTION
Add multiple market cranks by transaction using MAX_TX_INSTRUCTIONS env (default 1) Multiply cuLimit by number of markets per tx
Added PRIORITY_MARKETS env which allows user to pass in comma seperated list of markets to force use of PRIORITY_CU_PRICE when transaction includes that market updated Readme file