### PR TITLE
Adds an option to provide an alternate markets.json file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ to run in the background, pass "-d" or "--daemon"
                        // every market.
   INTERVAL             // Sleep interval, in ms, between each loop. Default is 
                        // 1000 ms
+  MARKETS_FILE         // Specify the full path to an alternate markets.json 
+                       // file. Default is '../markets.json'. This option will
+                       // let you run multiple instances with different 
+                       // settings for the markets. e.g. bump with "high fees"
+                       // or "medium fees" or other markets not included in the
+                       // default markets.json file.
   MAX_TX_INSTRUCTIONS  // Max number of instructions for each transaction. 
                        // Default is 1.
   MAX_UNIQUE_ACCOUNTS  // Max number of unique accounts to process in each

--- a/src/scripts/crank.ts
+++ b/src/scripts/crank.ts
@@ -3,7 +3,6 @@
  */
 import * as os from 'os';
 import * as fs from 'fs';
-import markets from '../markets.json';
 import {
   Keypair,
   Commitment,
@@ -43,7 +42,12 @@ const {
   MAX_TX_INSTRUCTIONS,  // max instructions per transaction
   CU_PRICE,             // extra microlamports per cu for any transaction
   PRIORITY_MARKETS,     // input to add comma seperated list of markets that force fee bump
+  MARKETS_FILE          // Specify the full path to an alternate markets.json file.
 } = process.env;
+
+// Read the alternate markets file if provided
+const marketsFile = MARKETS_FILE || '../markets.json';
+const markets = require(marketsFile);
 
 const cluster = CLUSTER || 'mainnet';
 const interval = INTERVAL || 1000;


### PR DESCRIPTION
Adds a new environment variable, `MARKETS_FILE`, to specify the full path to an alternate markets.json file. Default is '../markets.json'. This option will let you run multiple instances with different settings for the markets. e.g. bump with "high fees" or "medium fees" or crank other markets not included in the default markets.json file.