### PR TITLE
Add zstd compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "axios": "^1.3.2",
     "bn.js": "^5.1.0",
     "dotenv": "^10.0.0",
+    "fzstd": "^0.1.0",
     "tslog": "^3.3.4"
   },
   "resolutions": {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -45,7 +45,7 @@ export async function getMultipleAccounts(
   //use zstd to compress large responses
   let encoding = 'base64+zstd';
 
-  const args = commitment ? [publicKeyStrs, {commitment, encoding,minContextSlot}] : [publicKeyStrs, {encoding,minContextSlot}];
+  const args = [publicKeyStrs, {commitment,encoding,minContextSlot}];
 
   // @ts-ignore
   const resp = await connection._rpcRequest('getMultipleAccounts', args);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -40,7 +40,7 @@ export async function getMultipleAccounts(
   //use zstd to compress large responses
   let encoding = 'base64+zstd';
 
-  const args = commitment ? [publicKeyStrs, { commitment, encoding }] : [publicKeyStrs,{encoding}];
+  const args = commitment ? [publicKeyStrs, {commitment, encoding}] : [publicKeyStrs, {encoding}];
 
   // @ts-ignore
   const resp = await connection._rpcRequest('getMultipleAccounts', args);
@@ -61,7 +61,7 @@ export async function getMultipleAccounts(
       publicKey: publicKeys[i],
       context: resp.result.context,
       accountInfo: {
-        data: Buffer.from(fzstd.decompress(Buffer.from(data[0], 'base64') )),
+        data: Buffer.from(fzstd.decompress(Buffer.from(data[0], 'base64'))),
         executable,
         owner: new PublicKey(owner),
         lamports,


### PR DESCRIPTION
As it currently stands the responses we are getting from the GMA calls are massive e.g for 8 accounts the response size is over 4MB. I am doing some testing to see if we can trim these responses down further to reduce the sizes of the responses however in the meantime this seems to produce a measurable difference in performance at least while running the crank on my home 1Gbit network.

This change will reduce the response size by up to 10 times which should  decrease the transfer times over the network. In my tests I was getting around 200ms for GMA call / processing beforehand and down to 150ms which is about 25% increase in performance. I think if we can get the responses to be shorter by default then this may not be required and may hinder performance in some cases however as it stands now this should improve performance