### PR TITLE
utilize minContextSlot

### DIFF
--- a/src/scripts/crank.ts
+++ b/src/scripts/crank.ts
@@ -172,6 +172,9 @@ async function run() {
     (market) => market['_decoded'].eventQueue,
   );
 
+  //pass a minimum Context Slot to GMA
+  let minContextSlot = 0;
+
   // noinspection InfiniteLoopJS
   while (true) {
     try {
@@ -181,7 +184,12 @@ async function run() {
       const eventQueueAccts = await getMultipleAccounts(
         connection,
         eventQueuePks,
+        'processed',
+        minContextSlot,
       );
+
+     //increase the minContextSlot to avoid processing the same slot twice
+     minContextSlot = eventQueueAccts[0].context.slot + 1;
 
       for (let i = 0; i < eventQueueAccts.length; i++) {
         const accountInfo = eventQueueAccts[i].accountInfo;
@@ -279,11 +287,23 @@ async function run() {
 
       }
 
-      await sleep(interval);
+
 
     } catch (e) {
-      log.error(e);
+      if (e instanceof Error) {
+
+        switch (e.message){
+          case 'Minimum context slot has not been reached':
+            //lightweight warning message for known "safe" errors
+            log.warn(e.message);
+            break;
+          default:
+            log.error(e);
+        }
+
+      }
     }
+    await sleep(interval);
   }
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -13,6 +13,7 @@ export async function getMultipleAccounts(
   connection: Connection,
   publicKeys: PublicKey[],
   commitment?: Commitment,
+  minContextSlot?: number,
 ): Promise<
   {
     publicKey: PublicKey;
@@ -32,10 +33,15 @@ export async function getMultipleAccounts(
     ]).then((a) => a[0].concat(a[1]));
   }
   const publicKeyStrs = publicKeys.map((pk) => pk.toBase58());
+
   // load connection commitment as a default
   commitment ||= connection.commitment;
 
-  const args = commitment ? [publicKeyStrs, { commitment }] : [publicKeyStrs];
+  // set no minimum context slot by default
+  minContextSlot ||= 0;
+
+  const args = commitment ? [publicKeyStrs, { commitment,minContextSlot }] : [publicKeyStrs, {minContextSlot}];
+
   // @ts-ignore
   const resp = await connection._rpcRequest('getMultipleAccounts', args);
   if (resp.error) {


### PR DESCRIPTION
We can utilize minContextSlot to ensure that we do not process the same slots that we have already processed by passing the result of GMA context.slot to the subsequent call.

Note:
moved the sleep down to the end of the while loop - this will ensure that app will sleep when an iteration catches an error.