### PR TITLE
Load multiple markets simultaneously during startup

### DIFF
--- a/src/scripts/crank.ts
+++ b/src/scripts/crank.ts
@@ -13,7 +13,7 @@ import {
   BlockhashWithExpiryBlockHeight,
   TransactionInstruction,
 } from '@solana/web3.js';
-import {getMultipleAccounts,loadMultipleOpenbookMarkets,getMultipleTokenAccounts,  sleep,  chunk} from '../utils/utils';
+import {getMultipleAccounts,loadMultipleOpenbookMarkets,getMultipleAssociatedTokenAddresses,  sleep,  chunk} from '../utils/utils';
 import BN from 'bn.js';
 import {decodeEventQueue, DexInstructions} from '@project-serum/serum';
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
@@ -142,7 +142,7 @@ async function run() {
   const tokenAccounts = spotMarkets.map(
     (market) => market['_decoded'].baseMint
   );
-  const baseWallets = await getMultipleTokenAccounts(connection,payer,tokenAccounts);
+  const baseWallets = await getMultipleAssociatedTokenAddresses(connection,payer,tokenAccounts);
 
   const eventQueuePks = spotMarkets.map(
     (market) => market['_decoded'].eventQueue,

--- a/src/scripts/crank.ts
+++ b/src/scripts/crank.ts
@@ -13,13 +13,9 @@ import {
   BlockhashWithExpiryBlockHeight,
   TransactionInstruction,
 } from '@solana/web3.js';
-import { getMultipleAccounts, sleep, chunk } from '../utils/utils';
+import {getMultipleAccounts,loadMultipleOpenbookMarkets,getMultipleTokenAccounts,  sleep,  chunk} from '../utils/utils';
 import BN from 'bn.js';
-import {
-  decodeEventQueue,
-  DexInstructions,
-  Market,
-} from '@project-serum/serum';
+import {decodeEventQueue, DexInstructions} from '@project-serum/serum';
 import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { Logger } from 'tslog';
 import axios  from "axios"
@@ -125,20 +121,9 @@ async function run() {
   } else {
     marketsList = markets[cluster];
   }
+
   // load selected markets
-  const spotMarkets = await Promise.all(
-    marketsList.map((m) => {
-      return Market.load(
-        connection,
-        new PublicKey(m.address),
-        {
-          skipPreflight: true,
-          commitment: 'processed' as Commitment,
-        },
-        serumProgramId,
-      );
-    }),
-  );
+  let spotMarkets = await loadMultipleOpenbookMarkets(connection,serumProgramId,marketsList);
 
   log.info("Cranking the following markets");
   marketsList.forEach(m => log.info(`${m.name}: ${m.address}`));
@@ -153,20 +138,11 @@ async function run() {
     .getOrCreateAssociatedAccountInfo(payer.publicKey)
     .then((a) => a.address);
 
-  const baseWallets = await Promise.all(
-    spotMarkets.map((m) => {
-      const token = new Token(
-        connection,
-        m.baseMintAddress,
-        TOKEN_PROGRAM_ID,
-        payer,
-      );
-
-      return token
-        .getOrCreateAssociatedAccountInfo(payer.publicKey)
-        .then((a) => a.address);
-    }),
+  //get the token accounts for each basemint & the associated account address for our token account
+  const tokenAccounts = spotMarkets.map(
+    (market) => market['_decoded'].baseMint
   );
+  const baseWallets = await getMultipleTokenAccounts(connection,payer,tokenAccounts);
 
   const eventQueuePks = spotMarkets.map(
     (market) => market['_decoded'].eventQueue,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -118,7 +118,8 @@ export async function loadMultipleOpenbookMarkets(connection,programId,marketsLi
 }
 
 //get the associated accounts but don't check if they exist.
-export async function getMultipleTokenAccounts(connection,owner,tokenAccounts){
+//connection is passed to constructor but no RPC calls are made.
+export async function getMultipleAssociatedTokenAddresses(connection,owner,tokenAccounts){
 
   //token.associatedProgramId & token.programId will be the same for each token
   const token = new Token(connection, tokenAccounts[0].toString(), TOKEN_PROGRAM_ID, owner);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -98,7 +98,7 @@ export async function loadMultipleOpenbookMarkets(connection,programId,marketsLi
 
   //get all the token's decimal values
   const MINT_LAYOUT = buffer_layout.struct([buffer_layout.blob(44), buffer_layout.u8('decimals'), buffer_layout.blob(37)]);
-  let uniqueMintsPubKeys = Array.from(uniqueMints);
+  let uniqueMintsPubKeys: any[] = Array.from(uniqueMints);
   let uniqueMintsAccountInfos = await getMultipleAccounts(connection, uniqueMintsPubKeys, 'processed');
   uniqueMintsAccountInfos.forEach(function (result) {
     const {decimals} = MINT_LAYOUT.decode(result.accountInfo.data);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,6 +6,9 @@ import {
 } from '@solana/web3.js';
 
 import * as fzstd from 'fzstd';
+import {Market} from "@project-serum/serum";
+import * as buffer_layout from "buffer-layout";
+import { Token, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 
 export async function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -66,4 +69,65 @@ export async function getMultipleAccounts(
     );
   }))).flat();
 
+}
+
+//load multiple markets at once instead of calling getAccountInfo for each market 3 times
+//by default it is 1 call to get the market and 2 calls to get the decimals for baseMint and quoteMint
+//this can be condensed into 2 calls total per 100 markets
+export async function loadMultipleOpenbookMarkets(connection,programId,marketsList){
+
+  let marketsMap = new Map();
+  let decimalMap = new Map();
+  let uniqueMints = new Set();
+
+  //get all the market data for an openbook market
+  let pubKeys = marketsList.map((item) => new PublicKey(item.address));
+  let marketsAccountInfos = await getMultipleAccounts(connection, pubKeys, 'processed');
+  marketsAccountInfos.forEach(function (result) {
+    let layout = Market.getLayout(programId);
+    let decoded = layout.decode(result.accountInfo.data);
+    uniqueMints.add(decoded.baseMint);
+    uniqueMints.add(decoded.quoteMint);
+    marketsMap.set(result.publicKey.toString(), {
+      decoded: decoded,
+      baseMint: decoded.baseMint,
+      quoteMint: decoded.quoteMint,
+      programId: programId
+    });
+  });
+
+  //get all the token's decimal values
+  const MINT_LAYOUT = buffer_layout.struct([buffer_layout.blob(44), buffer_layout.u8('decimals'), buffer_layout.blob(37)]);
+  let uniqueMintsPubKeys = Array.from(uniqueMints);
+  let uniqueMintsAccountInfos = await getMultipleAccounts(connection, uniqueMintsPubKeys, 'processed');
+  uniqueMintsAccountInfos.forEach(function (result) {
+    const {decimals} = MINT_LAYOUT.decode(result.accountInfo.data);
+    decimalMap.set(result.publicKey.toString(), decimals);
+  });
+
+  //loop back through the markets and load the market with the decoded data and the base/quote decimals
+  let spotMarkets: Market[] = [];
+  marketsMap.forEach(function (market) {
+    let baseMint = market.baseMint.toString();
+    let quoteMint = market.quoteMint.toString();
+    let openbookMarket = new Market(market.decoded, decimalMap.get(baseMint), decimalMap.get(quoteMint), {}, programId, null);
+    spotMarkets.push(openbookMarket);
+  });
+
+  return spotMarkets;
+}
+
+//get the associated accounts but don't check if they exist.
+export async function getMultipleTokenAccounts(connection,owner,tokenAccounts){
+
+  //token.associatedProgramId & token.programId will be the same for each token
+  const token = new Token(connection, tokenAccounts[0].toString(), TOKEN_PROGRAM_ID, owner);
+  let associatedAccounts: PublicKey[] = [];
+
+  for (const tokenAccount of tokenAccounts) {
+    const associatedAddress = await Token.getAssociatedTokenAddress(token.associatedProgramId, token.programId, tokenAccount, owner.publicKey);
+    associatedAccounts.push(associatedAddress);
+  }
+
+  return associatedAccounts;
 }


### PR DESCRIPTION
Add function to load multiple openbook markets at once (this is done during startup) By default each market makes 3 calls to load, one to get the market account and 2 to calculate the decimal amounts for the `baseMint` and `quoteMint`. An example of how the calls look to load 8 markets is here: https://gyazo.com/1c08a078caacb50547767903a0e4e83f

As you can see there are many duplicates and many calls for loading a small number of markets. When I start to load more markets e.g. more than 25 I start to see RPC errors at least on my development machine. This PR request will combine the accounts needed during startup to a minimum of 2 calls (one for getting all of the market accounts and one for getting the decimals) if there are more than 100 markets then this may be increased by an additional call per 100 markets or so, (if decimals accounts are > 100 then additional calls will be made there too) see updated example here: https://gyazo.com/919a5c02ba1bd6f9d12a5a2c1ba03fae

Additionally this PR will replace the method of `getOrCreateAssociatedAccountInfo` for each baseMint. The associated account is passed into the `DexInstructions.consumeEvents` instruction (no idea why) as coinFee param. This means that the cranker has to create the ATA account for each token which costs more lamports to run. The additional overhead means more calls during startup to check if the account exists and create it if it does not. From what I can see this doesn't actually do anything and only adds the account to the transaction. The account doesn't need to actually exist for the transaction to crank. These calls have been replaced with a function to get the associated token address but not actually check it exists or create it. I tested this on some markets that nobody else was cranking and the assoc token account was referenced in the tx and the market was cranked without issue.
